### PR TITLE
Adding allowed characters for passphrase

### DIFF
--- a/UnstoppableWallet/UnstoppableWallet/Modules/CreateAccount/PassphraseValidator.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/CreateAccount/PassphraseValidator.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class PassphraseValidator {
-    static private let forbiddenSymbols = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789").inverted
+    static private let forbiddenSymbols = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 '\"`&/?!:;.,~*$=+-[](){}<>\\_#@|%").inverted
 
     func validate(text: String?) -> Bool {
         if text?.rangeOfCharacter(from: Self.forbiddenSymbols) != nil {


### PR DESCRIPTION
Added more characters that are supported by an BIP-39 compatible optional passphrase. These characters are what's used on Trezor and Ledger hardware wallets so they should also be allowed on Unstoppable Wallet. Ledger also limits the characters to 100 length but I am not too sure whether that's the maximum allowed characters for a passphrase. The reason why I have introduced this change is because I am unable to restore a Ledger/Trezor that has the additional characters (e.g !@#, etc...)